### PR TITLE
Card and header fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -131,7 +131,7 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.9", "", {}, "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="],
 
-    "@interknot/types": ["@interknot/types@github:Night-Sky-Studio/interknot-types#86c54bd", { "peerDependencies": { "typescript": "^5" } }, "Night-Sky-Studio-interknot-types-86c54bd"],
+    "@interknot/types": ["@interknot/types@github:Night-Sky-Studio/interknot-types#752d04c", { "peerDependencies": { "typescript": "^5" } }, "Night-Sky-Studio-interknot-types-752d04c"],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.8", "", { "dependencies": { "@jridgewell/set-array": "^1.2.1", "@jridgewell/sourcemap-codec": "^1.4.10", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA=="],
 

--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -269,10 +269,10 @@ export default function CharacterCard({ ref, uid, username, character, substatsV
                 if (!substatValueMap[subStat.Id]) {
                     substatValueMap[subStat.Id] = subStat.Value
                     substatNameMap[subStat.Id] = subStat.Name
-                    substatCountMap[subStat.Id] = 1
+                    substatCountMap[subStat.Id] = subStat.Level + 1
                 } else {
                     substatValueMap[subStat.Id] += subStat.Value
-                    substatCountMap[subStat.Id] += 1
+                    substatCountMap[subStat.Id] += subStat.Level + 1
                 }
             }
         }

--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -136,29 +136,31 @@ function CoreSkill({ level }: { level: number }): React.ReactElement {
     )
 }
 
-function Talents({ talentLevels, boosted }: { talentLevels: CharacterTalents, boosted?: boolean }): React.ReactElement {
+function Talents({ talentLevels, mindscapeLevel }: { talentLevels: CharacterTalents, mindscapeLevel: number }): React.ReactElement {
+    // mindscapeLevel >= 5 ? 4 : mindscapeLevel >= 3 ? 2 : 0
+    const mindscapeBoost = Math.floor(Math.min(mindscapeLevel, 6) / 2.5) * 2
     return (
-        <Group className={`cc-talents ${boosted ? "boosted" : ""}`} 
+        <Group className={`cc-talents ${mindscapeLevel > 2 ? "boosted" : ""}`} 
             gap="4px" justify="center" align="center" wrap="nowrap">
             <div className="cc-talent">
                 <TalentIcons.NormalAtk width="32px" />
-                <Title order={6} className="cc-talent-level">{talentLevels.BasicAttack}</Title>
+                <Title order={6} className="cc-talent-level">{talentLevels.BasicAttack + mindscapeBoost}</Title>
             </div>
             <div className="cc-talent">
                 <TalentIcons.Dodge width="32px" />
-                <Title order={6} className="cc-talent-level">{talentLevels.Dash}</Title>
+                <Title order={6} className="cc-talent-level">{talentLevels.Dash + mindscapeBoost}</Title>
             </div>
             <div className="cc-talent">
                 <TalentIcons.Switch width="32px" />
-                <Title order={6} className="cc-talent-level">{talentLevels.Assist}</Title>
+                <Title order={6} className="cc-talent-level">{talentLevels.Assist + mindscapeBoost}</Title>
             </div>
             <div className="cc-talent">
                 <TalentIcons.Skill width="32px" />
-                <Title order={6} className="cc-talent-level">{talentLevels.SpecialAttack}</Title>
+                <Title order={6} className="cc-talent-level">{talentLevels.SpecialAttack + mindscapeBoost}</Title>
             </div>
             <div className="cc-talent">
                 <TalentIcons.Ultimate width="32px" />
-                <Title order={6} className="cc-talent-level">{talentLevels.Ultimate}</Title>
+                <Title order={6} className="cc-talent-level">{talentLevels.Ultimate + mindscapeBoost}</Title>
             </div>
         </Group>
     )
@@ -310,7 +312,7 @@ export default function CharacterCard({ ref, uid, username, character, substatsV
                 <div className="cc-cell cc-skills">
                     <Stack gap="6px">
                         <CoreSkill level={character.CoreSkillEnhancement} />
-                        <Talents talentLevels={character.SkillLevels} boosted={character.MindscapeLevel >= 3} />
+                        <Talents talentLevels={character.SkillLevels} mindscapeLevel={character.MindscapeLevel} />
                     </Stack>
                     <Stack gap="4px" justify="flex-end">
                         {

--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -136,9 +136,10 @@ function CoreSkill({ level }: { level: number }): React.ReactElement {
     )
 }
 
-function Talents({ talentLevels }: { talentLevels: CharacterTalents }): React.ReactElement {
+function Talents({ talentLevels, boosted }: { talentLevels: CharacterTalents, boosted?: boolean }): React.ReactElement {
     return (
-        <Group className="cc-talents" gap="4px" justify="center" align="center" wrap="nowrap">
+        <Group className={`cc-talents ${boosted ? "boosted" : ""}`} 
+            gap="4px" justify="center" align="center" wrap="nowrap">
             <div className="cc-talent">
                 <TalentIcons.NormalAtk width="32px" />
                 <Title order={6} className="cc-talent-level">{talentLevels.BasicAttack}</Title>
@@ -309,7 +310,7 @@ export default function CharacterCard({ ref, uid, username, character, substatsV
                 <div className="cc-cell cc-skills">
                     <Stack gap="6px">
                         <CoreSkill level={character.CoreSkillEnhancement} />
-                        <Talents talentLevels={character.SkillLevels} />
+                        <Talents talentLevels={character.SkillLevels} boosted={character.MindscapeLevel >= 3} />
                     </Stack>
                     <Stack gap="4px" justify="flex-end">
                         {

--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -14,7 +14,7 @@ function MindscapeIcons({ level, size }: { level: number, size?: number }): Reac
     size = size || 16;
     const isActive = (lvl: number): string => (lvl <= level) ? "#fdf003" : "#4A4A4A";
     return (
-        <Group gap="4px" h="100%">
+        <Group gap="4px" h="100%" wrap="nowrap">
             <Mindscapes.Ms1 width={size} height={size} color={isActive(1)} />
             <Mindscapes.Ms2 width={size} height={size} color={isActive(2)} />
             <Mindscapes.Ms3 width={size} height={size} color={isActive(3)} />
@@ -27,7 +27,7 @@ function MindscapeIcons({ level, size }: { level: number, size?: number }): Reac
 
 function CharacterLevel({ level, msLevel }: { level: number, msLevel: number }): React.ReactElement {
     return (
-        <Group gap="0" h="16px" align="center">
+        <Group gap="0" h="16px" align="center" wrap="nowrap">
             <div className="cc-level">
                 <Title order={6} fz="10px">Lv. {level}</Title>
             </div>
@@ -50,7 +50,7 @@ function CharacterName({ name, element, profession, level, msLevel }: ICharacter
     const { getLocalString } = useSettings()
     return (
         <Stack gap="0">
-            <Group gap="4px">
+            <Group gap="4px" wrap="nowrap">
                 <Title order={3} className="cc-character-name">{getLocalString(name)}</Title>
                 <ZenlessIcon elementName={element} size={16} />
                 <ProfessionIcon name={profession} />
@@ -71,7 +71,7 @@ interface ICharacterCardProps {
 function WeaponEngine({ weapon }: { weapon?: Weapon }): React.ReactElement {
     const WeaponStat = ({ stat }: { stat: Property }) => {
         return (
-            <Group gap="6px" className="cc-weapon-stat">
+            <Group gap="6px" className="cc-weapon-stat" wrap="nowrap">
                 <ZenlessIcon id={stat.Id} size={12} />
                 <Title order={6} fz="9px">{stat.formatted}</Title>
             </Group>
@@ -82,7 +82,7 @@ function WeaponEngine({ weapon }: { weapon?: Weapon }): React.ReactElement {
 
     return (
         <div className="cc-weapon">
-            <Group gap="8px">
+            <Group gap="8px" wrap="nowrap" >
                 <div className="cc-weapon-icon">
                     <Image src={weapon?.ImageUrl} />
                     <Image src={getRarityIcon(weapon?.Rarity ?? 0)} alt={weapon?.Rarity.toString()} />
@@ -90,12 +90,12 @@ function WeaponEngine({ weapon }: { weapon?: Weapon }): React.ReactElement {
                 {weapon && 
                     <Stack gap="4px" justify="center"> 
                         <Title order={6} fz="11px">{getLocalString(weapon.Name)}</Title>
-                        <Group gap="16px" align="flex-end">
-                            <Group gap="4px">
+                        <Group gap="16px" align="flex-end" wrap="nowrap">
+                            <Group gap="4px" wrap="nowrap">
                                 <WeaponStat stat={weapon.MainStat} />
                                 <WeaponStat stat={weapon.SecondaryStat} />
                             </Group>
-                            <Group gap="4px">
+                            <Group gap="4px" wrap="nowrap">
                                 <div className="cc-weapon-stat level">
                                     <Title order={6} fz="8px">Lv. {weapon.Level}</Title>
                                 </div>
@@ -138,7 +138,7 @@ function CoreSkill({ level }: { level: number }): React.ReactElement {
 
 function Talents({ talentLevels }: { talentLevels: CharacterTalents }): React.ReactElement {
     return (
-        <Group className="cc-talents" gap="4px" justify="center" align="center">
+        <Group className="cc-talents" gap="4px" justify="center" align="center" wrap="nowrap">
             <div className="cc-talent">
                 <TalentIcons.NormalAtk width="32px" />
                 <Title order={6} className="cc-talent-level">{talentLevels.BasicAttack}</Title>
@@ -177,7 +177,7 @@ function SubStat({ stat }: { stat: Property }): React.ReactElement {
 
     return (
         <Stack className="cc-disc-stat" gap="1px">
-            <Group align="flex-start" gap="4px">
+            <Group align="flex-start" gap="4px" wrap="nowrap">
                 <ZenlessIcon id={stat.Id} size={12} />
                 <Title order={6} fz="11px" mt="-2px" h="12px">{stat.formatted}</Title>
             </Group>

--- a/src/components/LeaderboardButton.tsx
+++ b/src/components/LeaderboardButton.tsx
@@ -17,9 +17,25 @@ interface ILeaderboardButtonProps {
 }
 
 export function LeaderboardButton({ id, agent, weapon, name, rank, total, type, onClick }: ILeaderboardButtonProps) {
+    // https://stackoverflow.com/a/9462382/10990079
+    const nFormatter = (num: number, digits: number) => {
+        const lookup = [
+            { value: 1, symbol: "" },
+            { value: 1e3, symbol: "k" },
+            { value: 1e6, symbol: "M" },
+            { value: 1e9, symbol: "G" },
+            { value: 1e12, symbol: "T" },
+            { value: 1e15, symbol: "P" },
+            { value: 1e18, symbol: "E" }
+        ]
+        const regexp = /\.0+$|(?<=\.[0-9]*[1-9])0+$/
+        const item = lookup.findLast(item => num >= item.value)
+        return item ? (num / item.value).toFixed(digits).replace(regexp, "").concat(item.symbol) : "0"
+    }
+
     const navigate = useNavigate()
 
-    const { getLocalString } = useSettings()
+    const { decimalPlaces, getLocalString } = useSettings()
 
     const [opened, { toggle, close }] = useDisclosure(false)
 
@@ -37,8 +53,8 @@ export function LeaderboardButton({ id, agent, weapon, name, rank, total, type, 
                         </Group>
                         <Stack gap="0px" className="lb-info">
                             <Title order={6} fz="12px">{name}</Title>
-                            <Title order={6} fz="14px" ff="zzz-jp">Top {((rank / total) * 100).toFixed(1)}%</Title>
-                            <Title order={6} fz="10px" ff="zzz-jp">{rank} / {total}</Title>
+                            <Title order={6} fz="14px" ff="zzz-jp">Top {((rank / total) * 100).toFixed(decimalPlaces)}%</Title>
+                            <Title order={6} fz="10px" ff="zzz-jp">{rank} / {nFormatter(total, 1)}</Title>
                         </Stack>
                     </Group>
                 </UnstyledButton>

--- a/src/components/SettingsProvider.tsx
+++ b/src/components/SettingsProvider.tsx
@@ -2,21 +2,13 @@ import { createContext, useCallback, useContext, useEffect } from "react"
 import { useLocalStorage } from "@mantine/hooks"
 import { Localizations } from "../localization/Localization"
 
-export enum Unit {
-    CritValue = "CV",
-    RollValue = "RV"
-}
-export const Units: Unit[] = [Unit.CritValue, Unit.RollValue]
-
 type InterknotSettingsBase = {
-    units: Unit,
     decimalPlaces: number,
     language: string,
     lbButtonVariant: number,
 }
 
 type InterknotSettings = InterknotSettingsBase & {
-    setUnits: (value: Unit) => void,
     setDecimalPlaces: (value: number) => void,
     setLanguage: (value: string) => void,
     getLocalString: (value: string) => string,
@@ -24,15 +16,13 @@ type InterknotSettings = InterknotSettingsBase & {
 }
 
 const defaultSettings: InterknotSettingsBase = {
-    units: Unit.CritValue,
-    decimalPlaces: 2,
+    decimalPlaces: 1,
     language: navigator.language.split("-")[0],
     lbButtonVariant: 0
 }
 
 const defaultCallbacks: InterknotSettings = {
     ...defaultSettings,
-    setUnits: () => {},
     setDecimalPlaces: () => {},
     setLanguage: () => {},
     getLocalString: () => "",
@@ -44,7 +34,6 @@ export const SettingsContext = createContext(defaultCallbacks)
 export function SettingsProvider({ children }: { children: React.ReactNode }) {
     const [settings, setSettings] = useLocalStorage<InterknotSettingsBase>({ key: "settings", defaultValue: defaultSettings })
 
-    const setUnits = (units: Unit) => setSettings((prev) => ({ ...prev, units }))
     const setDecimalPlaces = (decimalPlaces: number) => setSettings((prev) => ({ ...prev, decimalPlaces }))
     const setLanguage = (language: string) => setSettings((prev) => ({ ...prev, language }))
     const setLbButtonVariant = (lbButtonVariant: number) => setSettings((prev => ({ ...prev, lbButtonVariant })))
@@ -60,7 +49,6 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     return (
         <SettingsContext.Provider value={{ 
             ...settings, 
-            setUnits, 
             setDecimalPlaces, 
             setLanguage, 
             getLocalString,

--- a/src/components/UserHeader.tsx
+++ b/src/components/UserHeader.tsx
@@ -50,13 +50,15 @@ export function UserHeader({ user, showDescription }: IUserHeaderProps): React.R
             <Group className="user-data">         
                 <Avatar className="namecard-avatar" src={user.ProfilePictureUrl} size="xl" mr="sm" />
                 <Stack align="flex-start" justify="flex-start" gap="4px"
-                    style={{ "--color-a": `#${user.Title.ColorA}`, "--color-b": `#${user.Title.ColorB}` }}>
+                    style={{ "--color-a": `#${user.Title?.ColorA ?? "FFFFFF"}`, "--color-b": `#${user.Title?.ColorB ?? "FFFFFF"}` }}>
                     <Title order={2} className="namecard-nickname" title={user.Nickname}>{user.Nickname}</Title>
-                    <Center className="namecard-title">
-                        <Title className="namecard-title" order={6}>
-                            {getLocalString(user.Title.Text)}
-                        </Title>
-                    </Center>
+                    {user.Title && 
+                        <Center className="namecard-title">
+                            <Title className="namecard-title" order={6}>
+                                {getLocalString(user.Title.Text)}
+                            </Title>
+                        </Center>
+                    }
                 </Stack>
                 <Stack className="user-achievements" align="flex-end" justify="flex-start" gap="4px">
                     <Group gap="4px">

--- a/src/components/styles/CharacterCard.css
+++ b/src/components/styles/CharacterCard.css
@@ -227,6 +227,9 @@ html[lang="fr"] .cc-stat * {
 .cc-talent * {
     font-size: 6px;
 }
+.cc-talents.boosted .cc-talent-level {
+    color: var(--mantine-color-yellow-5);
+}
 .cc-talent-level {
     font-family: "zzz-jp", monospace !important;
     /* letter-spacing: -1px; */

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { Card, Stack, Title, Text, Group, SegmentedControl, useCombobox, Select } from "@mantine/core"
-import { Unit, Units, useSettings } from "../components/SettingsProvider"
+import { useSettings } from "../components/SettingsProvider"
 import { AvailableLocs } from "../localization/Localization"
 
 export default function SettingsPage() {
@@ -42,12 +42,6 @@ export default function SettingsPage() {
                                 throw new Error("Language is null?????")
                             settings.setLanguage(val)
                         }} />
-                </Group>
-                <Group gap="sm">
-                    <Text>Current artifact unit:</Text>
-                    <SegmentedControl data={Units} value={settings.units} onChange={(val) => {
-                        settings.setUnits(val as Unit)
-                    }}></SegmentedControl>
                 </Group>
                 <Group gap="sm">
                     <Text>TOP% decimal places:</Text>


### PR DESCRIPTION
Fixes #49, #50, #48

- Substats breakdown not count all substat procs
- Character with mindscapes now has their talent levels displayed correctly
- Removed Units (RV, CV)
- Implemented decimal places setting in leaderboard button
- Fixed unset title not being handled propely