### PR TITLE
Leaderboards Team information

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -203,7 +203,7 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
 
-    "@interknot/types": ["@interknot/types@github:Night-Sky-Studio/interknot-types#de80c80", { "peerDependencies": { "typescript": "^5" } }, "Night-Sky-Studio-interknot-types-de80c80"],
+    "@interknot/types": ["@interknot/types@github:Night-Sky-Studio/interknot-types#d4dfcb3", { "peerDependencies": { "typescript": "^5" } }, "Night-Sky-Studio-interknot-types-d4dfcb3"],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 

--- a/src/components/CharacterCard/CharacterCard.tsx
+++ b/src/components/CharacterCard/CharacterCard.tsx
@@ -376,7 +376,7 @@ function StatsGraph({ leaderboard, entry, color }: IStatsGraphProps): React.Reac
                                 <Title order={6} m="0" fz="14px">{leaderboard.Name}</Title>
                             </Group>
                         </Group>
-                        <Team h="64px" team={[leaderboard.Character, ...leaderboard.Team]} />
+                        <Team h="64px" team={leaderboard.Team} />
                         {showRanking
                             ? <div className="cc-graph-lb">
                                 {entry.Rank} / {leaderboard.Total}

--- a/src/components/DriveDiscCard/DriveDiscCard.css
+++ b/src/components/DriveDiscCard/DriveDiscCard.css
@@ -72,6 +72,7 @@
 
 .disc-title {
     display: inline-block;
+    margin-right: 32px
 }
 .disc-title > * {
     display: inline;

--- a/src/components/DriveDiscCard/DriveDiscCard.tsx
+++ b/src/components/DriveDiscCard/DriveDiscCard.tsx
@@ -28,7 +28,7 @@ export default function DriveDiscCard({ disc }: { disc: DD }): React.ReactElemen
         <Card className="disc-card">
             <Card.Section bg={getDriveDiscGradient(disc.SetId)} h="96px">
                 <div className="disc-header">
-                    <div style={{ position: "relative" }}>
+                    <div>
                         <div className="disc-header-img">
                             <div className="disc-highlight" />
                             <Image draggable={false} className="disc-img" src={disc.IconUrl} alt={disc.Name} />

--- a/src/components/DriveDiscCard/DriveDiscCard.tsx
+++ b/src/components/DriveDiscCard/DriveDiscCard.tsx
@@ -28,11 +28,9 @@ export default function DriveDiscCard({ disc }: { disc: DD }): React.ReactElemen
         <Card className="disc-card">
             <Card.Section bg={getDriveDiscGradient(disc.SetId)} h="96px">
                 <div className="disc-header">
-                    <div>
-                        <div className="disc-header-img">
-                            <div className="disc-highlight" />
-                            <Image draggable={false} className="disc-img" src={disc.IconUrl} alt={disc.Name} />
-                        </div>
+                    <div className="disc-header-img">
+                        <div className="disc-highlight" />
+                        <Image draggable={false} className="disc-img" src={disc.IconUrl} alt={disc.Name} />
                     </div>
                     <Badge color="dark" radius="4px" ff="zzz-jp" style={{ position: "absolute", right: "8px", top: "8px", padding: "0 6px" }}>{disc.Slot}</Badge>
                     <Stack gap="0">    

--- a/src/components/DriveDiscCard/DriveDiscCard.tsx
+++ b/src/components/DriveDiscCard/DriveDiscCard.tsx
@@ -1,4 +1,4 @@
-import { Card, Group, Stack, Title, Image } from "@mantine/core"
+import { Card, Group, Stack, Title, Image, Badge } from "@mantine/core"
 import "./DriveDiscCard.css"
 import { DriveDisc as DD, Property } from "@interknot/types"
 import { ZenlessIcon, getDriveDiscGradient, getRarityIcon } from "@components/icons/Icons"
@@ -28,10 +28,13 @@ export default function DriveDiscCard({ disc }: { disc: DD }): React.ReactElemen
         <Card className="disc-card">
             <Card.Section bg={getDriveDiscGradient(disc.SetId)} h="96px">
                 <div className="disc-header">
-                    <div className="disc-header-img">
-                        <div className="disc-highlight" />
-                        <Image draggable={false} className="disc-img" src={disc.IconUrl} alt={disc.Name} />
+                    <div style={{ position: "relative" }}>
+                        <div className="disc-header-img">
+                            <div className="disc-highlight" />
+                            <Image draggable={false} className="disc-img" src={disc.IconUrl} alt={disc.Name} />
+                        </div>
                     </div>
+                    <Badge color="dark" radius="4px" ff="zzz-jp" style={{ position: "absolute", right: "8px", top: "8px", padding: "0 6px" }}>{disc.Slot}</Badge>
                     <Stack gap="0">    
                         <span className="disc-title">
                             <Title order={3} c="white">{getLocalString(disc.Name)}</Title>

--- a/src/components/LeaderboardsList/LeaderboardsList.tsx
+++ b/src/components/LeaderboardsList/LeaderboardsList.tsx
@@ -1,7 +1,7 @@
 
 import { nFormatter, toFixedCeil } from "@/extensions/NumberExtensions"
 import { BaseLeaderboardEntry, LeaderboardList } from "@interknot/types"
-import { Card, Group, Text, Image, Table, ScrollArea } from "@mantine/core"
+import { Card, Group, Text, Image, Table, ScrollArea, Anchor } from "@mantine/core"
 import { useSettings } from "@components/SettingsProvider"
 import { Team } from "@components/Team/Team"
 import "./LeaderboardsList.css"
@@ -21,41 +21,7 @@ export default function LeaderboardsList({ leaderboards, entries, highlightId }:
     const LeaderboardRow = ({ entry }: { entry: BaseLeaderboardEntry }) => {
         const leaderboard = leaderboards.find(lb => lb.Id === entry.Leaderboard.Id)
         return (
-            <Table.Tr className={highlightId === entry.Leaderboard.Id ? "highlight": ""} 
-                onMouseUp={(evt) => {
-                    evt.preventDefault()
-                    evt.stopPropagation()
-                    // left click -> navigate
-                    if (evt.button === 0) {
-                        navigate(`/leaderboards/${entry.Leaderboard.Id}`)
-                        return
-                    }
-                    // middle click -> open in new tab
-                    if (evt.button === 1) {
-                        const url = `/leaderboards/${entry.Leaderboard.Id}`
-                        window.open(url, "_blank", "noreferrer noopener")
-                    }
-                }} 
-                onContextMenu={(evt) => {
-                    evt.preventDefault()
-                    const url = `/leaderboards/${entry.Leaderboard.Id}`
-                    let anchor = document.getElementById("ctx-anchor") as HTMLAnchorElement | null
-                    if (!anchor) {
-                        anchor = document.createElement("a")
-                        anchor.id = "ctx-anchor"
-                        anchor.target = "_blank"
-                        anchor.rel = "noreferrer noopener"
-                        document.body.appendChild(anchor)
-                    }
-                    anchor.href = url
-                    const event = new MouseEvent("contextmenu", {
-                        ...evt,
-                        view: window,
-                        bubbles: true,
-                        cancelable: true
-                    })
-                    anchor.dispatchEvent(event)
-                }}>
+            <Table.Tr className={highlightId === entry.Leaderboard.Id ? "highlight": ""}>
                 <Table.Td>
                     <Text>{entry.Rank}<Text component="span" c="dimmed"> / {nFormatter(entry.Leaderboard.Total)}</Text></Text>
                 </Table.Td>
@@ -63,13 +29,20 @@ export default function LeaderboardsList({ leaderboards, entries, highlightId }:
                     <Text>top {toFixedCeil((entry.Rank / entry.Leaderboard.Total) * 100, decimalPlaces)}%</Text>
                 </Table.Td>
                 <Table.Td>
-                    <Group gap="4px" wrap="nowrap">
-                        <Image src={entry.Leaderboard.Weapon.ImageUrl} h="24px" />
-                        <Text>{getLocalString(entry.Leaderboard.Weapon.Name)}</Text>
-                    </Group>
+                    <Anchor href={`/leaderboards/${entry.Leaderboard.Id}`} c="inherit"
+                        onClick={(e) => {
+                            e.preventDefault()
+                            e.stopPropagation()
+                            navigate(`/leaderboards/${entry.Leaderboard.Id}`)
+                        }}>
+                        <Group gap="4px" wrap="nowrap">
+                            <Image src={entry.Leaderboard.Weapon.ImageUrl} h="24px" />
+                            { getLocalString(entry.Leaderboard.Weapon.Name) }
+                        </Group>
+                    </Anchor>
                 </Table.Td>
                 <Table.Td>
-                    { leaderboard && <Team team={[entry.Leaderboard.Character, ...leaderboard.Team]} /> }
+                    { leaderboard && <Team compact team={leaderboard.Team} /> }
                 </Table.Td>
                 <Table.Td>
                     <Text>{entry.Leaderboard.FullName}</Text>

--- a/src/components/Team/Team.css
+++ b/src/components/Team/Team.css
@@ -1,16 +1,66 @@
 .member {
-    aspect-ratio: 180 / 250;
+   border-radius: 2px 4px 2px 4px; 
+}
+.member {
+    /* width: 90px; */
     height: 100%;
-    border-radius: 2px 4px 2px 4px;
-    transform: skew(16deg);
+    /* border-radius: 4px 8px 4px 8px; */
     background-color: var(--mantine-color-dark-9);
-    outline: var(--mantine-color-dark-5) solid 1px;
+    border : var(--mantine-color-dark-5) solid 2px;
     position: relative;
     overflow: hidden;
     display: flex;
     justify-content: center;
+    align-items: center;
+}
+.member-agent {
+    aspect-ratio: 180 / 250;
 }
 .member > * {
+    height: 100%;
+}
+.member-equipment {
+    padding: 4px 0;
+    margin-right: 0px;
+    transform: skew(16deg);
+}
+.member-equipment .member {
+    width: auto;
+    margin-left: -2px;
+}
+.member-equipment:has(> :first-child):not(:has(> :nth-child(2))) .member:first-child {
+    border-radius: 0 4px 2px 0;
+}
+.member-equipment:has(> :nth-child(2)) .member:nth-child(1) {
+    border-radius: 0 4px 0 0;
+    margin-bottom: -1px;
+}
+.member-equipment:has(> :nth-child(2)) .member:nth-child(2) {
+    border-radius: 0 0 4px 0;
+    margin-top: -1px;
+}
+.member-equipment .member * {
+    transform: skew(-16deg);
+}
+.member-level {
+    position: absolute;
+    height: auto;
+    bottom: -2px;
+    left: -2px;
+    padding: 2px 6px;
+    font-family: "zzz";
+    color: white;
+    background-color: var(--mantine-color-dark-5);
+    border-radius: 0 8px 0 0;
+    transform: skew(8deg) !important;
+}
+.member-level > * {
+    transform: skew(-24deg) !important;
+}
+.member-skew {
+    transform: skew(16deg);
+}
+.member-skew > * {
     transform: skew(-16deg);
 }
 .empty-member::before {

--- a/src/components/Team/Team.tsx
+++ b/src/components/Team/Team.tsx
@@ -1,39 +1,100 @@
-import { BaseAvatar } from "@interknot/types"
-import { Group, Image, Tooltip } from "@mantine/core"
+import { LeaderboardTeamMember } from "@interknot/types"
+import { Group, Image, Stack, Title, Tooltip } from "@mantine/core"
 import "./Team.css"
 import { useSettings } from "@components/SettingsProvider"
-import { useMemo } from "react"
-import { useBackend } from "@components/BackendProvider.tsx"
+import { ProfessionIcon } from "../icons/Icons";
 
-function TeamMember({ ref, avatar }: { ref?: any, avatar: BaseAvatar }) {
-    // FIXME: needs proper img replacing solution
-    const { state } = useBackend()
-    const hasDoro = useMemo(() => state?.data?.events?.doro?.includes(avatar.Id) ?? false,
-        [state?.data?.events?.doro, avatar.Id])
-    const url = useMemo(() =>
-        hasDoro
-            ? avatar.ImageUrl.replace("enka.network", "cdn.interknot.space/aprilfools")
-            : avatar.CircleIconUrl.replace("Circle", "Select"),
-        [hasDoro, avatar.CircleIconUrl, avatar.ImageUrl])
+function EmptyMember({ compact = false }: { compact?: boolean }) {
+    return <Title h="auto" order={compact ? 6 : 3} c="white">?</Title>
+}
+
+function MemberLevel({ level, weapon = false }: { level: number, weapon?: boolean }) {
     return (
-        <div className="member" ref={ref}>
-            <Image h="100%" ml={hasDoro ? "1rem" : undefined} src={url} alt={avatar.Name} />
+        <div className="member-level">
+            <Title h="auto" fz="50%" c="white">{weapon ? `P${level}` : `M${level}`}</Title>
         </div>
     )
 }
 
-export function Team({ team, h }: { team: BaseAvatar[], h?: string }) {
-    const { getLocalString } = useSettings()
+function TeamMember({ member, compact = false }: { member: LeaderboardTeamMember, compact?: boolean }) {
+    const { language, getLocalString } = useSettings()
+    const agent = member.Character,
+          mindscape = member.MindscapeLevel ?? 0,
+          weapon = member.Weapon,
+          weaponRefinement = member.WeaponRefinement ?? 1,
+          set = member.DriveDiscSet,
+          speciality = member.Speciality
+
+    const tooltipText = agent 
+        ? `${getLocalString(agent.Name ?? "")} (M${mindscape})`
+        : speciality 
+            ? `${speciality} agent`
+            : "Any agent"
+
     return (
-        <Group gap="4px" h={h ?? "32px"} wrap="nowrap">
-            {team.map((avatar) => (
-                <Tooltip key={avatar.Id} label={getLocalString(avatar.Name)} portalProps={{ reuseTargetNode: true }}>
-                    <TeamMember avatar={avatar} />
-                </Tooltip>
+        <Group h="100%" wrap="nowrap" gap="0">
+            <Tooltip label={tooltipText} portalProps={{ reuseTargetNode: true }}>
+                <div className="member member-agent member-skew" style={{ zIndex: 1 }}>
+                    {
+                        speciality && <ProfessionIcon name={speciality} h="50%" />
+
+                    }
+                    {
+                        agent && <> 
+                            <Image h="100%" style={{ position: "relative" }}
+                                src={agent.CircleIconUrl.replace("Circle", "Select")} alt={agent.Name} /> 
+                            { !compact && mindscape > 0 && <MemberLevel level={mindscape} /> }
+                        </>
+                    }
+                    {
+                        !speciality && !agent && <EmptyMember compact={compact} />
+                    }
+                </div>
+            </Tooltip>
+            
+            { !compact &&
+                <Stack className="member-equipment" gap="0" justify="flex-end" h="100%">
+                    {
+                        weapon && 
+                            <div className="member" style={{ height: "50%" }}
+                                data-zzz-type="weapon" data-zzz-lang={language}
+                                data-zzz-id={weapon.Id} data-zzz-level={60}
+                                data-zzz-promote={6} data-zzz-index={weaponRefinement}>
+                                <Image src={weapon.ImageUrl} alt={weapon.Name} />
+                                { weaponRefinement > 1 && <MemberLevel weapon level={weaponRefinement} /> }
+                            </div>
+                    }
+                    {
+                        set && 
+                            <div className="member" style={{ height: "50%" }}
+                                data-zzz-type="artifact" data-zzz-lang={language}
+                                data-zzz-level={4} data-zzz-id={set.Id}>
+                                <Image p="4px" src={set.IconUrl} alt={set.Name} />
+                            </div>
+                    }
+                </Stack>
+            }
+        </Group>
+    )
+}
+
+export interface ITeamProps {
+    team: LeaderboardTeamMember[]
+    h?: string
+    compact?: boolean
+}
+
+export function Team({ team, h, compact = false }: ITeamProps) {
+    return (
+        <Group gap={compact ? "2px" : "4px"} h={h ?? "32px"} wrap="nowrap" data-compact={compact}>
+            {team.map((m, idx) => (
+                <TeamMember key={m.Character?.Id ?? m.Speciality ?? `any-${idx}`} member={m} compact={compact} />
             ))}
             {Array.from({ length: 3 - team.length }, (_, i) => (
                 <Tooltip key={i} label={"Any agent"} portalProps={{ reuseTargetNode: true }}>
-                    <div className="member empty-member" />
+                    <div className="member member-agent member-skew">
+                        <EmptyMember compact={compact} />
+                    </div>
                 </Tooltip>
             ))}
         </Group>

--- a/src/components/UserHeader/UserHeader.css
+++ b/src/components/UserHeader/UserHeader.css
@@ -63,7 +63,8 @@
     left: 50%;
     /* voodoo abs positioned element centering hack  */
     transform: translateX(-50%); 
-    padding: 0 16px;
+    text-align: center;
+    min-width: 48px;
 
     background-color: var(--mantine-color-dark-9);
     border-radius: var(--mantine-radius-sm);

--- a/src/components/WeaponButton.tsx
+++ b/src/components/WeaponButton.tsx
@@ -1,24 +1,43 @@
 import { BaseWeapon } from "@interknot/types"
-import { ActionIcon, Image } from "@mantine/core"
+import { ActionIcon, Badge, Button, Image, Tooltip } from "@mantine/core"
 import { useNavigate } from "react-router"
 import { useSettings } from "./SettingsProvider"
 
 interface IWeaponButtonProps {
     id: number
     weapon: BaseWeapon
+    refinementLevel?: number
+    compact?: boolean
     selected?: boolean
 }
 
-export default function WeaponButton({ id, weapon, selected } : IWeaponButtonProps): React.ReactElement {
+export default function WeaponButton({ id, weapon, refinementLevel = 1, compact = false, selected = false } : IWeaponButtonProps): React.ReactElement {
     const navigate = useNavigate()
     const { getLocalString } = useSettings()
+
+    const WeaponIcon = () => (<div className="weapon-icon" style={{ position: "relative" }}>
+        <Image h="38px" src={weapon.ImageUrl} alt={getLocalString(weapon.Name)} />
+        <Badge color="gray.9" size="xs" style={{ position: "absolute", bottom: "-4px", right: "-2px" }}>P{refinementLevel}</Badge>
+    </div>)
+
     return (
-        <ActionIcon variant={selected ? "filled" : "subtle"} p="0" style={{ overflow: "visible" }}
-            onClick={(e) => {
-                e.stopPropagation()
-                navigate(`/leaderboards/${id}`)
-            }}>
-            <Image h="38px" src={weapon.ImageUrl} alt={getLocalString(weapon.Name)} />
-        </ActionIcon>
+        compact
+            ? <Tooltip label={`${getLocalString(weapon.Name)} (P${refinementLevel})`} portalProps={{ reuseTargetNode: true }}>
+                <ActionIcon variant={selected ? "filled" : "subtle"} p="0" style={{ overflow: "visible" }}
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        navigate(`/leaderboards/${id}`)
+                    }}>
+                    <WeaponIcon />
+                </ActionIcon>
+            </Tooltip>
+            : <Button variant={selected ? "filled" : "subtle"} p="1.5rem 0.5rem" 
+                style={{ overflow: "visible" }}
+                onClick={(e) => {
+                    e.stopPropagation()
+                    navigate(`/leaderboards/${id}`)
+                }} leftSection={<WeaponIcon />}>
+                { getLocalString(weapon.Name) }
+            </Button>
     )
 }

--- a/src/components/icons/Icons.tsx
+++ b/src/components/icons/Icons.tsx
@@ -83,12 +83,14 @@ const ProfessionsMap: Record<string, string> = {
 interface IProfessionIconProps {
     name: string
     size?: number
+    h?: string
+    w?: string
     style?: React.CSSProperties
     className?: string
 }
 
-export function ProfessionIcon({ name, size, style, className }: IProfessionIconProps): React.ReactElement {
-    return (<Image className={className} style={style} h={(size ?? 16) + "px"} src={ProfessionsMap[name]} alt={name} />)
+export function ProfessionIcon({ name, size, h, w, style, className }: IProfessionIconProps): React.ReactElement {
+    return (<Image className={className} style={style} h={h ?? (size ?? 16) + "px"} w={w} src={ProfessionsMap[name]} alt={name} />)
 }
 
 export function getRarityIcon(rarity: number): string | undefined {

--- a/src/index.css
+++ b/src/index.css
@@ -107,7 +107,7 @@ text {
     background: var(--mantine-datatable-background-color) !important;
 }
 
-.data-table .mantine-Table-thead .mantine-Table-tr:first-child {
+.data-table:not(.dt-header) .mantine-Table-thead .mantine-Table-tr:first-child {
     display: none;
 }
 .mantine-Table-td.mantine-datatable-row-expansion-cell {

--- a/src/pages/KitchenSinkPage.tsx
+++ b/src/pages/KitchenSinkPage.tsx
@@ -1,4 +1,4 @@
-import { Stack, Loader, Tabs, Title, Text, Code } from "@mantine/core"
+import { Stack, Loader, Tabs, Title, Text, Code, Divider } from "@mantine/core"
 import { useAsync } from "react-use"
 import { useMemo } from "react"
 import { getCharacters, getProfile } from "@/api/data"
@@ -6,6 +6,7 @@ import "@components/cells/styles/CritCell.css"
 import "@components/cells/styles/WeaponCell.css"
 import "./styles/TestPage.css"
 import { UserHeader } from "@/components/UserHeader/UserHeader"
+import { Team } from "@components/Team/Team.tsx"
 // import BuildActions from "@/components/BuildActions"
 // import { DataProvider } from "@/components/DataProvider"
 // import { ICardContext } from "@/components/CharacterCard/CharacterCard"
@@ -44,31 +45,73 @@ function ProfileTab() {
 function BuildsTab() {
     const buildsState = useAsync(async () => getCharacters({ uid }), [])
     const builds = useMemo(() => buildsState.value?.data, [buildsState.value?.data])
-    // const build = useMemo(() => builds ? builds[0] : undefined, [builds])
+    const agent = useMemo(() => builds?.[0]?.Character, [builds])
 
     return <Stack p="md">
+        <Title>Builds</Title>
         { buildsState.loading && <Loader /> }
-        { builds && <></>
-            // <DataProvider data={{
-            //     build: build
-            // } satisfies Partial<ICardContext>}>
-            //     <Stack>
-            //         <BuildActions location="modal" />
-            //         <BuildActions location="footer" />
-            //     </Stack>
-            // </DataProvider>
-        }
+        { builds && agent && <Stack>
+            <Text>Compact: <Code>false</Code></Text>
+            <Team h="128px" team={[ 
+                { 
+                    Character: agent, 
+                    MindscapeLevel: 6,
+                    Weapon: agent.Weapon!,
+                    WeaponRefinement: 5,
+                    DriveDiscSet: agent.DriveDisksSet[0].Set 
+                },
+                {
+                    Speciality: "Support",
+                    DriveDiscSet: agent.DriveDisksSet[1].Set
+                }
+            ]} />
+
+            <Text>Compact: <Code>true</Code></Text>
+            <Team h="128px" compact team={[ 
+                { 
+                    Character: agent, 
+                    MindscapeLevel: 6,
+                    Weapon: agent.Weapon!,
+                    WeaponRefinement: 5,
+                    DriveDiscSet: agent.DriveDisksSet[0].Set 
+                },
+                {
+                    Speciality: "Support",
+                    DriveDiscSet: agent.DriveDisksSet[1].Set
+                }
+            ]} />
+
+            <div>
+                <Text>Compact: <Code>true</Code></Text>
+                <Text>Height: <Code>64px</Code></Text>
+            </div>
+            <Team h="64px" compact team={[ 
+                { 
+                    Character: agent, 
+                    MindscapeLevel: 6,
+                    Weapon: agent.Weapon!,
+                    WeaponRefinement: 5,
+                    DriveDiscSet: agent.DriveDisksSet[0].Set 
+                },
+                {
+                    Speciality: "Support",
+                    DriveDiscSet: agent.DriveDisksSet[1].Set
+                }
+            ]} />
+        </Stack>}
     </Stack>
 }
 
 export default function KitchenSinkPage() {
     return (<>
-        <Tabs defaultValue="main">
+        <Tabs defaultValue="main" variant="pills">
             <Tabs.List>
                 <Tabs.Tab value="main">Application</Tabs.Tab>
                 <Tabs.Tab value="profile">Profile</Tabs.Tab>
                 <Tabs.Tab value="builds">Builds</Tabs.Tab>
             </Tabs.List>
+
+            <Divider mt="lg" />
 
             <Tabs.Panel value="main"><ApplicationTab /></Tabs.Panel>
             <Tabs.Panel value="profile"><ProfileTab /></Tabs.Panel>

--- a/src/pages/KitchenSinkPage.tsx
+++ b/src/pages/KitchenSinkPage.tsx
@@ -56,7 +56,7 @@ function DiscsTab() {
                 <Title order={2}>Drive Disc Card</Title>
                 <Flex gap="md">
                     { 
-                        discs.map(dd => <DriveDiscCard disc={dd} />)
+                        discs.map(dd => <DriveDiscCard key={dd.Uid} disc={dd} />)
                     }
                 </Flex>
             </>

--- a/src/pages/KitchenSinkPage.tsx
+++ b/src/pages/KitchenSinkPage.tsx
@@ -1,12 +1,13 @@
-import { Stack, Loader, Tabs, Title, Text, Code, Divider } from "@mantine/core"
+import { Stack, Loader, Tabs, Title, Text, Code, Divider, Flex } from "@mantine/core"
 import { useAsync } from "react-use"
 import { useMemo } from "react"
-import { getCharacters, getProfile } from "@/api/data"
+import { getCharacters, getDriveDiscs, getProfile } from "@/api/data"
 import "@components/cells/styles/CritCell.css"
 import "@components/cells/styles/WeaponCell.css"
 import "./styles/TestPage.css"
 import { UserHeader } from "@/components/UserHeader/UserHeader"
 import { Team } from "@components/Team/Team.tsx"
+import DriveDiscCard from "@/components/DriveDiscCard/DriveDiscCard";
 // import BuildActions from "@/components/BuildActions"
 // import { DataProvider } from "@/components/DataProvider"
 // import { ICardContext } from "@/components/CharacterCard/CharacterCard"
@@ -39,6 +40,28 @@ function ProfileTab() {
                 <UserHeader user={profile} variant="compact" />
             </>
         }
+    </Stack>
+}
+
+function DiscsTab() {
+    const discsState = useAsync(async () => await getDriveDiscs({ uid, limit: 4 }), [uid])
+    const discs = useMemo(() => discsState.value?.data, [discsState.value?.data])
+
+
+    return <Stack p="md">
+        <Title>Drive Discs</Title>
+
+        { discsState.loading && <Loader /> }
+        { discs && <>
+                <Title order={2}>Drive Disc Card</Title>
+                <Flex gap="md">
+                    { 
+                        discs.map(dd => <DriveDiscCard disc={dd} />)
+                    }
+                </Flex>
+            </>
+        }
+           
     </Stack>
 }
 
@@ -108,6 +131,7 @@ export default function KitchenSinkPage() {
             <Tabs.List>
                 <Tabs.Tab value="main">Application</Tabs.Tab>
                 <Tabs.Tab value="profile">Profile</Tabs.Tab>
+                <Tabs.Tab value="discs">Drive Discs</Tabs.Tab>
                 <Tabs.Tab value="builds">Builds</Tabs.Tab>
             </Tabs.List>
 
@@ -115,6 +139,7 @@ export default function KitchenSinkPage() {
 
             <Tabs.Panel value="main"><ApplicationTab /></Tabs.Panel>
             <Tabs.Panel value="profile"><ProfileTab /></Tabs.Panel>
+            <Tabs.Panel value="discs"><DiscsTab /></Tabs.Panel>
             <Tabs.Panel value="builds"><BuildsTab /></Tabs.Panel>
         </Tabs>
         

--- a/src/pages/LeaderboardDetailPage.tsx
+++ b/src/pages/LeaderboardDetailPage.tsx
@@ -212,14 +212,16 @@ export default function LeaderboardDetailPage(): React.ReactElement {
                                     {
                                         relatedLeaderboards.map(lb => {
                                             return (
-                                                <WeaponButton id={lb.Id} weapon={lb.Weapon} selected={lb.Id === Number(id)} />
+                                                <WeaponButton id={lb.Id} weapon={lb.Weapon} 
+                                                    compact refinementLevel={lb.Weapon.Rarity === 4 ? 1 : 5}
+                                                    selected={lb.Id === Number(id)} />
                                             )
                                         })
                                     }
                                 </Group>
                                 <Group gap="xs">
                                     <Title order={5}>Team</Title>
-                                    <Team h="64px" team={[leaderboard.Character, ...leaderboard.Team]} />
+                                    <Team h="80px" team={leaderboard.Team} />
                                 </Group>
                                 <Stack gap="xs" align="flex-start">
                                     <Group gap="0">

--- a/src/pages/LeaderboardDetailPage.tsx
+++ b/src/pages/LeaderboardDetailPage.tsx
@@ -212,7 +212,7 @@ export default function LeaderboardDetailPage(): React.ReactElement {
                                     {
                                         relatedLeaderboards.map(lb => {
                                             return (
-                                                <WeaponButton id={lb.Id} weapon={lb.Weapon} 
+                                                <WeaponButton key={lb.Id} id={lb.Id} weapon={lb.Weapon} 
                                                     compact refinementLevel={lb.Weapon.Rarity === 4 ? 1 : 5}
                                                     selected={lb.Id === Number(id)} />
                                             )

--- a/src/pages/LeaderboardsPage.tsx
+++ b/src/pages/LeaderboardsPage.tsx
@@ -1,13 +1,14 @@
 import { useAsyncRetry } from "react-use"
 import { getLeaderboards } from "../api/data"
-import { Card, Center, Group, Image, Loader, Stack, Table, Text, Title, Alert, Anchor } from "@mantine/core"
+import { Card, Center, Group, Image, Loader, Stack, Text, Title, Alert, Anchor, Flex } from "@mantine/core"
 import { ProfessionIcon, ZenlessIcon } from "../components/icons/Icons"
 import { IconInfoCircle } from "@tabler/icons-react"
 import { useNavigate } from "react-router"
 import { Team } from "@components/Team/Team"
 import WeaponButton from "@components/WeaponButton"
 import { useMemo } from "react"
-import { useBackend } from "@components/BackendProvider.tsx"
+// import { useBackend } from "@components/BackendProvider.tsx"
+import { DataTable } from "mantine-datatable"
 
 export default function LeaderboardsPage(): React.ReactElement {
     const navigate = useNavigate()
@@ -16,11 +17,11 @@ export default function LeaderboardsPage(): React.ReactElement {
         return await getLeaderboards({})
     })
 
-    const leaderboards = useMemo(() => leaderboardsState.value?.data, [leaderboardsState.value])
+    const leaderboards = useMemo(() => leaderboardsState.value?.data?.sort((a, b) => b.Total - a.Total), [leaderboardsState.value])
 
-    const { state } = useBackend()
-    const doro = useMemo(() => state?.data?.events?.doro ?? [], [state?.data?.events?.doro])
-    const doroMode = useMemo(() => doro.length > 0, [doro.length])
+    // const { state } = useBackend()
+    // const doro = useMemo(() => state?.data?.events?.doro ?? [], [state?.data?.events?.doro])
+    // const doroMode = useMemo(() => doro.length > 0, [doro.length])
 
     return (<>
         <title>Leaderboards | Inter-Knot</title>
@@ -55,56 +56,85 @@ export default function LeaderboardsPage(): React.ReactElement {
             }
             {leaderboardsState.value &&
                 <Card p="0" withBorder radius="md">
-                    <Table stickyHeader>
-                        <Table.Thead>
-                            <Table.Tr>
-                                <Table.Th>#</Table.Th>
-                                <Table.Th>Name</Table.Th>
-                                <Table.Th>Weapons</Table.Th>
-                                <Table.Th>Team</Table.Th>
-                                <Table.Th>Total</Table.Th>
-                            </Table.Tr>
-                        </Table.Thead>
-                        <Table.Tbody>
-                            {leaderboards?.sort((a, b) => b.Total - a.Total).map((leaderboard, index) => {
-                                // FIXME: needs proper img replacing solution
-                                const url = leaderboard.Character.CircleIconUrl
-                                const src = doroMode && doro.includes(leaderboard.Character.Id)
-                                    ? url.replace("enka.network", "cdn.interknot.space/aprilfools")
-                                    : url
-
-                                return (
-                                    <Table.Tr key={leaderboard.Id} onClick={() => {
-                                        navigate(`/leaderboards/${leaderboard.Id}`)
-                                    }}>
-                                        <Table.Td>{index + 1}</Table.Td>
-                                        <Table.Td>
+                    <Stack>
+                        <DataTable highlightOnHover
+                            className="data-table dt-header"
+                            records={leaderboards}
+                            idAccessor="Id"
+                            columns={[
+                                {
+                                    accessor: "Id",
+                                    title: "#",
+                                    cellsStyle: () => ({ maxWidth: "2ch" }),
+                                    render: (_, index) => <Text fz="inherit">{index + 1}</Text>
+                                },
+                                {
+                                    accessor: "FullName",
+                                    title: "Name",
+                                    render: (leaderboard) => {
+                                        return (
                                             <Group gap="xs">
                                                 <ZenlessIcon size={24} elementName={leaderboard.Character.ElementTypes[0]} />
                                                 <ProfessionIcon size={24} name={leaderboard.Character.ProfessionType} />
-                                                <Image h="32px" src={src} alt={leaderboard.Character.Name} />
-                                                {leaderboard.FullName}
+                                                <Image h="32px" src={leaderboard.Character.CircleIconUrl} 
+                                                    alt={leaderboard.Character.Name} />
+                                                <Anchor href={`/leaderboards/${leaderboard.Id}`} onClick={(e) => {
+                                                    e.stopPropagation()
+                                                    e.preventDefault()
+                                                    navigate(`/leaderboards/${leaderboard.Id}`)
+                                                }} c="inherit" fz="inherit">
+                                                    {leaderboard.FullName}
+                                                </Anchor>
                                             </Group>
-                                        </Table.Td>
-                                        <Table.Td>
-                                            <Group gap="xs">
-                                                <WeaponButton id={leaderboard.Id} weapon={leaderboard.Weapon} />
-                                                {
-                                                    leaderboard.Children.map((child) => (
-                                                        <WeaponButton key={child.Id} id={child.Id} weapon={child.Weapon} />
-                                                    ))
-                                                }
-                                            </Group>
-                                        </Table.Td>
-                                        <Table.Td>
-                                            <Team team={[leaderboard.Character, ...leaderboard.Team]} />
-                                        </Table.Td>
-                                        <Table.Td>{leaderboard.Total}</Table.Td>
-                                    </Table.Tr>
+                                        )
+                                    }
+                                },
+                                {
+                                    accessor: "Weapons",
+                                    title: "Weapons",
+                                    render: (leaderboard) => (
+                                        <Group gap="xs">
+                                            {
+                                                [leaderboard, ...leaderboard.Children].map((child) => (
+                                                    <WeaponButton key={child.Id} id={child.Id} compact
+                                                        refinementLevel={child.Weapon.Rarity === 4 ? 1 : 5} 
+                                                        weapon={child.Weapon} />
+                                                ))
+                                            }
+                                        </Group>
+                                    )
+                                },
+                                {
+                                    accessor: "Team",
+                                    title: "Team",
+                                    render: (leaderboard) => <Team compact h="36px" team={leaderboard.Team} />
+                                },
+                                {
+                                    accessor: "Total",
+                                    title: "Total"
+                                }
+                            ]} 
+                            rowExpansion={{
+                                allowMultiple: true,
+                                content: ({ record: leaderboard }) => (
+                                    <Flex w="100%" justify="space-evenly" align="center">
+                                        <Stack p="md" gap="xs" align="flex-start">
+                                            <Text fz="sm" c="dimmed">Weapons</Text>
+                                            {
+                                                [leaderboard, ...leaderboard.Children].map((child) => (
+                                                    <WeaponButton key={child.Id} id={child.Id} 
+                                                        weapon={child.Weapon} refinementLevel={child.Weapon.Rarity === 4 ? 1 : 5} />
+                                                ))
+                                            }
+                                        </Stack>
+                                        <Stack p="md" gap="xs">
+                                            <Text fz="sm" c="dimmed">Team</Text>
+                                            <Team h="96px" team={leaderboard.Team} />
+                                        </Stack>
+                                    </Flex>
                                 )
-                            })}
-                        </Table.Tbody>
-                    </Table>
+                            }} />
+                    </Stack>
                 </Card>
             }
         </Stack>


### PR DESCRIPTION
Fixes #83 
Fixes #95 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded leaderboard pages with a richer sortable table, clickable navigation, and row expansion for weapons and team details.
  * Added drive disc views to the Kitchen Sink page, including updated drive disc cards with a header badge.
  * Enhanced weapon rendering with refinement badges and a new compact mode.
  * Reworked team display to be driven by leaderboard team members (with compact layout support).

* **Bug Fixes**
  * Corrected which team members are shown in leaderboard team/leaderboard card footers and detail pages.
  * Adjusted leaderboard row interaction to navigate via the name/weapon cell only.

* **UI/Style**
  * Updated spacing/alignment across headers and cards, plus refined team tile styling and icon sizing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->